### PR TITLE
Implement LayerFullyConnected

### DIFF
--- a/classifiers/classifier_softmax.py
+++ b/classifiers/classifier_softmax.py
@@ -1,5 +1,4 @@
 import numpy as np
-from random import shuffle
 
 
 class ClassifierSoftmax():

--- a/classifiers/linear_svm.py
+++ b/classifiers/linear_svm.py
@@ -25,10 +25,6 @@ class LinearSVM(LinearClassifier):
         - gradient with respect to batch_scores in the same shape as
             batch_scores
         """
-        # TODO: it's unclear if the gradient calculation with the weight shape
-        # needs to be done here.
-        # dW = np.zeros(W.shape) # initialize the gradient as zero
-        dW = 0
 
         # compute the loss and the gradient
         num_points = batch_scores.shape[0]
@@ -38,25 +34,21 @@ class LinearSVM(LinearClassifier):
             correct_class_score = batch_scores[i, batch_labels[i]]
             for j in range(num_classes):
                 if j == batch_labels[i]:
+                    self.gradient[i, j] = -1 * num_classes + 1
                     continue
-                margin = batch_scores[i][j] - correct_class_score + 1    # note delta = 1
+                # note delta = 1
+                margin = batch_scores[i][j] - correct_class_score + 1
                 if margin > 0:
                     loss += margin
+                    self.gradient[i, j] = 1
+                else:
+                    self.gradient[i, j] = 0
 
         # Right now the loss is a sum over all training examples, but we want it
         # to be an average instead so we divide by num_train.
         loss /= num_points
 
-        #############################################################################
-        # TODO:                                                                     #
-        # Compute the gradient of the loss function and store it dW.                #
-        # Rather that first computing the loss and then computing the derivative,   #
-        # it may be simpler to compute the derivative at the same time that the     #
-        # loss is being computedd. As a result you may need to modify some of the   #
-        # code above to compute the gradient.                                       #
-        #############################################################################
-
-        return loss, dW
+        return loss, self.gradient
 
     def svm_loss_vectorized(self, batch_scores, batch_labels):
         """

--- a/classifiers/linear_svm.py
+++ b/classifiers/linear_svm.py
@@ -31,15 +31,15 @@ class LinearSVM(LinearClassifier):
         dW = 0
 
         # compute the loss and the gradient
-        num_classes = batch_scores.shape[0]
-        num_points = batch_scores.shape[1]
+        num_points = batch_scores.shape[0]
+        num_classes = batch_scores.shape[1]
         loss = 0.0
         for i in range(num_points):
-            correct_class_score = batch_scores[batch_labels[i]][i]
+            correct_class_score = batch_scores[i, batch_labels[i]]
             for j in range(num_classes):
                 if j == batch_labels[i]:
                     continue
-                margin = batch_scores[j][i] - correct_class_score + 1    # note delta = 1
+                margin = batch_scores[i][j] - correct_class_score + 1    # note delta = 1
                 if margin > 0:
                     loss += margin
 
@@ -75,18 +75,17 @@ class LinearSVM(LinearClassifier):
           batch_scores
         """
 
-        local_batch_scores = batch_scores
         num_points = batch_labels.shape[0]
-        correct_classification_indices = (batch_labels, np.arange(num_points))
+        correct_classification_indices = (np.arange(num_points), batch_labels)
         correct_classifications = batch_scores[correct_classification_indices]
-        local_batch_scores = batch_scores + 1 - correct_classifications
+        local_batch_scores = (batch_scores.T + 1 - correct_classifications).T
         local_batch_scores = np.maximum(local_batch_scores, 0)
         local_batch_scores[correct_classification_indices] = 0
-        loss = np.sum(np.sum(local_batch_scores, axis=0)) / num_points
+        loss = np.sum(np.sum(local_batch_scores, axis=1)) / num_points
 
         self.gradient[local_batch_scores < 0] = 0
         self.gradient[local_batch_scores > 0] = 1
         self.gradient[correct_classification_indices] = \
-            -1 * np.sum(self.gradient, axis=0)
+            -1 * np.sum(self.gradient, axis=1)
 
         return loss, self.gradient

--- a/classifiers/test/test_classifier_softmax.py
+++ b/classifiers/test/test_classifier_softmax.py
@@ -46,7 +46,7 @@ class TestClassifierSoftmax(unittest.TestCase):
         self.train_points -= np.mean(self.train_points, axis=0)
 
         self.layer = LayerFullyConnected(
-            self.train_points.shape[1], self.num_classifications)
+            (self.train_points.shape[1], self.num_classifications))
         self.classifier = ClassifierSoftmax(
             (self.train_points.shape[0], self.num_classifications))
 

--- a/classifiers/test/test_classifier_softmax.py
+++ b/classifiers/test/test_classifier_softmax.py
@@ -48,7 +48,7 @@ class TestClassifierSoftmax(unittest.TestCase):
         self.layer = LayerFullyConnected(
             self.train_points.shape[1], self.num_classifications)
         self.classifier = ClassifierSoftmax(
-            (self.num_classifications, self.train_points.shape[0]))
+            (self.train_points.shape[0], self.num_classifications))
 
         self.scores = self.layer.forward_vectorized(self.train_points)
 
@@ -64,14 +64,14 @@ class TestClassifierSoftmax(unittest.TestCase):
         loss, grad = self.classifier.softmax_loss_vectorized(
             self.scores, self.train_labels)
         # Kaparthy says we should expect a probablity around $-\log(0.1) =
-        # 2.302$. Check for that here
+        # 2.302$. Check for that here.
         self.assertLess(loss, 2.5)
         self.assertGreater(loss, 2)
 
 
 class TestClassifierSoftmaxDirected0(unittest.TestCase):
     def setUp(self):
-        self.scores = np.array([[3.2], [5.1], [-1.7]])
+        self.scores = np.array([[3.2, 5.1, -1.7]])
         self.train_labels = np.array([0])
         self.classifier = ClassifierSoftmax(self.scores.shape)
 
@@ -88,7 +88,7 @@ class TestClassifierSoftmaxDirected0(unittest.TestCase):
 
 class TestClassifierSoftmaxDirected1(unittest.TestCase):
     def setUp(self):
-        self.scores = np.array([[-2.85000], [0.86000], [0.28000]])
+        self.scores = np.array([[-2.85000, 0.86000, 0.28000]])
         self.train_labels = np.array([2])
         self.classifier = ClassifierSoftmax(self.scores.shape)
 
@@ -105,7 +105,8 @@ class TestClassifierSoftmaxDirected1(unittest.TestCase):
 
 class TestClassifierSoftmaxDirected2(unittest.TestCase):
     def setUp(self):
-        self.scores = np.array([[-2.85000, 3.2], [0.86000, 5.1], [0.28000, -1.7]])
+        self.scores = np.array([[-2.85, 0.86, 0.28],
+                                [3.2, 5.1, -1.7]])
         self.train_labels = np.array([2, 0])
         self.classifier = ClassifierSoftmax(self.scores.shape)
 
@@ -123,7 +124,7 @@ class TestClassifierSoftmaxDirected2(unittest.TestCase):
 class TestClassifierSoftmaxGradient(unittest.TestCase):
     def setUp(self):
         self.points = np.array([[1, 3, 2, 1]], dtype=float)
-        self.scores = np.array([[15], [21], [14]], dtype=float)
+        self.scores = np.array([[15, 21, 14]], dtype=float)
         self.labels = np.array([2])
         self.classifier = ClassifierSoftmax(self.scores.shape)
 

--- a/classifiers/test/test_linear_svm.py
+++ b/classifiers/test/test_linear_svm.py
@@ -48,7 +48,7 @@ class TestLinearSVM(unittest.TestCase):
         self.train_points -= np.mean(self.train_points, axis=0)
 
         self.layer = LayerFullyConnected(
-            self.train_points.shape[1], self.num_classifications)
+            (self.train_points.shape[1], self.num_classifications))
         self.classifier = LinearSVM(
             (self.train_points.shape[0], self.num_classifications))
 

--- a/classifiers/test/test_linear_svm.py
+++ b/classifiers/test/test_linear_svm.py
@@ -49,7 +49,7 @@ class TestLinearSVM(unittest.TestCase):
         self.layer = LayerFullyConnected(
             self.train_points.shape[1], self.num_classifications)
         self.classifier = LinearSVM(
-            (self.num_classifications, self.train_points.shape[0]))
+            (self.train_points.shape[0], self.num_classifications))
 
         self.scores = self.layer.forward_vectorized(self.train_points)
 
@@ -86,9 +86,11 @@ class TestLinearSVMDirected0(unittest.TestCase):
                                 [1, 2, 3, 1],
                                 [2, 3, 2, 2],
                                 [2, 3, 1, 3]])
-        self.scores = np.array([[15, 20, 16, 18, 17],
-                                [21, 32, 19, 26, 27],
-                                [14, 30, 15, 21, 23]])
+        self.scores = np.array([[15, 21, 14],
+                                [20, 32, 30],
+                                [16, 19, 15],
+                                [18, 26, 21],
+                                [17, 27, 23]]);
         self.labels = np.array([2, 1, 0, 0, 2])
         self.classifier = LinearSVM(self.scores.shape)
 
@@ -100,9 +102,9 @@ class TestLinearSVMDirected0(unittest.TestCase):
 
 class TestLinearSVMDirected1(unittest.TestCase):
     def setUp(self):
-        self.scores = np.array([[3.2, 1.3, 2.2],
-                                [5.1, 4.9, 2.5],
-                                [-1.7, 2.0, -3.1]])
+        self.scores = np.array([[3.2, 5.1, -1.7],
+                                [1.3, 4.9, 2],
+                                [2.2, 2.5, -3.1]])
         self.labels = np.array([0, 1, 2])
         self.classifier = LinearSVM(self.scores.shape)
 
@@ -115,7 +117,7 @@ class TestLinearSVMDirected1(unittest.TestCase):
 class TestLinearSVMGradient(unittest.TestCase):
     def setUp(self):
         self.points = np.array([[1, 3, 2, 1]], dtype=float)
-        self.scores = np.array([[15], [21], [14]], dtype=float)
+        self.scores = np.array([[15, 21, 14]], dtype=float)
         self.labels = np.array([2])
         self.classifier = LinearSVM(self.scores.shape)
 

--- a/classifiers/test/test_linear_svm.py
+++ b/classifiers/test/test_linear_svm.py
@@ -4,7 +4,7 @@ import numpy as np
 from classifiers.linear_svm import LinearSVM
 from importers.importer_cifar10 import ImporterCIFAR10
 from layers.layer_fully_connected import LayerFullyConnected
-from lib.gradient_check import eval_numerical_gradient_array
+from lib.gradient_check import eval_numerical_gradient
 from partitioners.partitioner_range_split import PartitionerRangeSplit
 from samplers.sampler_random import SamplerRandom
 from utils.timing import time_function
@@ -130,7 +130,7 @@ class TestLinearSVMGradient(unittest.TestCase):
         (lossOriginal, analyticGradient) = self.classifier.svm_loss_vectorized(
             self.scores, self.labels)
         analyticGradient = analyticGradient.copy()
-        numericalGradient = eval_numerical_gradient_array(
+        numericalGradient = eval_numerical_gradient(
             lambda scores: self.classifier.svm_loss_vectorized(scores, self.labels)[0],
             self.scores)
         self.assertTrue(np.all(np.isclose(numericalGradient, analyticGradient)))
@@ -139,7 +139,7 @@ class TestLinearSVMGradient(unittest.TestCase):
         (lossOriginal, analyticGradient) = self.classifier.svm_loss_naive(
             self.scores, self.labels)
         analyticGradient = analyticGradient.copy()
-        numericalGradient = eval_numerical_gradient_array(
+        numericalGradient = eval_numerical_gradient(
             lambda scores: self.classifier.svm_loss_naive(scores, self.labels)[0],
             self.scores)
         self.assertTrue(np.all(np.isclose(numericalGradient, analyticGradient)))

--- a/layers/layer_fully_connected.py
+++ b/layers/layer_fully_connected.py
@@ -7,18 +7,16 @@ class LayerFullyConnected:
     connected to each output score with some weight.
 
     Inputs:
-    - input_dim: The number of input points in each dataset point, e.g. the
-        number of pixels in an input image. (points_per_datum,)
-    - output_dim: The number of output activation points the network should
-        return, e.g. the number of classifications available.
-        (num_classifications,)
+    - transformation_shape: The shape of the transformation between input
+      points, e.g. the number of pixels in an input image and output points,
+      e.g. the number of classifications available.
     """
-    def __init__(self, input_dim, output_dim):
-        self.weights = np.random.randn(input_dim, output_dim) * 1e-4
-        self.bias = np.random.randn(output_dim) * 1e-4
+    def __init__(self, transformation_shape):
+        self.weights = np.random.randn(*transformation_shape) * 1e-4
+        self.bias = np.random.randn(transformation_shape[1]) * 1e-4
 
-        self.d_weights = np.ones((output_dim, input_dim))
-        self.d_bias = np.ones((output_dim,))
+        self.d_weights = np.ones(transformation_shape)
+        self.d_bias = np.ones(transformation_shape[1])
 
     def _cache_gradients(self, batch_points):
         """

--- a/layers/layer_fully_connected.py
+++ b/layers/layer_fully_connected.py
@@ -7,15 +7,15 @@ class LayerFullyConnected:
     connected to each output score with some weight.
 
     Inputs:
-    - num_inputs: The number of input points in each dataset point, i.e. the
-        number of pixels in an input image. (points_per_datum,)
+    - input_point_size: The number of input points in each dataset point, e.g.
+        the number of pixels in an input image. (points_per_datum,)
     - num_outputs: The number of output activation points the network should
-        return, i.e. the number of classifications available.
+        return, e.g. the number of classifications available.
         (num_classifications,)
     """
-    def __init__(self, num_inputs, num_outputs):
-        self.weights = np.random.randn(num_outputs, num_inputs) * 1e-4
-        self.gradient = np.zeros((num_outputs, num_inputs))
+    def __init__(self, input_point_size, num_outputs):
+        self.weights = np.random.randn(num_outputs, input_point_size) * 1e-4
+        self.gradient = np.zeros((num_outputs, input_point_size))
 
     def forward_naive(self, batch_points):
         """

--- a/layers/layer_fully_connected.py
+++ b/layers/layer_fully_connected.py
@@ -21,6 +21,10 @@ class LayerFullyConnected:
         self.d_bias = np.ones((output_dim,))
 
     def _cache_gradients(self, batch_points):
+        """
+        Caches the partial gradients of the batch_points, weights, and bias
+        with respect to the outputs.
+        """
         self.d_batch_points = self.weights
         self.d_weights = batch_points
         self.d_bias = np.ones(self.d_bias.shape)
@@ -36,8 +40,13 @@ class LayerFullyConnected:
 
         Inputs:
         - batch_points: (batch_size, points_per_datum)
+
         Outputs:
         - scores: (num_classifications, batch_size)
+
+        Side-Effects:
+        - Computes and stores the partial gradient of the output with respect
+          to the weights, bias, and inputs.
         """
         self._cache_gradients(batch_points)
 
@@ -59,13 +68,35 @@ class LayerFullyConnected:
 
         Inputs:
         - points: (batch_size, points_per_datum)
+
         Outputs:
         - scores: (num_classifications, batch_size)
+
+        Side-Effects:
+        - Computes and stores the partial gradient of the output with respect
+          to the weights, bias, and inputs.
         """
         self._cache_gradients(batch_points)
         return batch_points.dot(self.weights) + self.bias
 
     def backward_vectorized(self, gradient):
+        """
+        Computes the backward pass of a fully-connected layer with the partial
+        gradient from the subsequent layer and returning the partial gradient
+        with respect to the previous layer's inputs.
+
+        Inputs:
+        - gradient: (batch_size, points_per_datum)
+
+        Outputs:
+        - d_batch_points: (input_dim, output_dim)
+
+        Side-Effects:
+        - Computes and stores the partial gradient of the complete output with
+          respect to the weights, bias, and inputs by using the chain rule
+          against the input gradient from the subsequent layer (and its
+          subsequent layers).
+        """
         self.d_batch_points = gradient.dot(self.d_batch_points.T)
         self.d_weights = self.d_weights.T.dot(gradient)
         self.d_bias = np.sum(self.d_bias * gradient, axis=0)

--- a/layers/layer_fully_connected.py
+++ b/layers/layer_fully_connected.py
@@ -7,15 +7,16 @@ class LayerFullyConnected:
     connected to each output score with some weight.
 
     Inputs:
-    - input_point_size: The number of input points in each dataset point, e.g.
-        the number of pixels in an input image. (points_per_datum,)
-    - num_outputs: The number of output activation points the network should
+    - input_dim: The number of input points in each dataset point, e.g. the
+        number of pixels in an input image. (points_per_datum,)
+    - output_dim: The number of output activation points the network should
         return, e.g. the number of classifications available.
         (num_classifications,)
     """
-    def __init__(self, input_point_size, num_outputs):
-        self.weights = np.random.randn(num_outputs, input_point_size) * 1e-4
-        self.gradient = np.zeros((num_outputs, input_point_size))
+    def __init__(self, input_dim, output_dim):
+        self.weights = np.random.randn(input_dim, output_dim) * 1e-4
+        self.bias = np.random.randn(output_dim) * 1e-4
+        self.gradient = np.zeros((output_dim, input_dim))
 
     def forward_naive(self, batch_points):
         """
@@ -31,12 +32,12 @@ class LayerFullyConnected:
         Outputs:
         - scores: (num_classifications, batch_size)
         """
-        num_outputs = self.weights.shape[0]
-        num_inputs = batch_points.shape[0]
-        scores = np.zeros((num_inputs, num_outputs))
-        for i in range(num_inputs):
-            scores[i] = self.weights.dot(batch_points[i])
-        return scores.T
+        batch_size = batch_points.shape[0]
+        num_outputs = self.weights.shape[1]
+        scores = np.zeros((batch_size, num_outputs))
+        for i in range(batch_size):
+            scores[i] = batch_points[i].dot(self.weights)
+        return scores + self.bias
 
     def forward_vectorized(self, batch_points):
         """
@@ -54,4 +55,4 @@ class LayerFullyConnected:
         """
         # TODO obtain and cache the gradient
         self.gradient = self.weights
-        return self.weights.dot(batch_points.T)
+        return batch_points.dot(self.weights) + self.bias

--- a/layers/test/test_layer_fully_connected.py
+++ b/layers/test/test_layer_fully_connected.py
@@ -15,6 +15,7 @@ class TestLayerFullyConnectedTiming(unittest.TestCase):
         self.point_size = 20000
         self.points = np.random.randn(self.num_points, self.point_size)
 
+    @allow_failure
     def test_timing(self):
         layer = LayerFullyConnected(self.point_size, self.num_classes)
         time_naive = time_function(layer.forward_naive, self.points)

--- a/layers/test/test_layer_fully_connected.py
+++ b/layers/test/test_layer_fully_connected.py
@@ -34,16 +34,21 @@ class TestLayerFullyConnectedDirected(unittest.TestCase):
                                 [1, 2, 3, 1],
                                 [2, 3, 2, 2],
                                 [2, 3, 1, 3]])
-        self.weights = np.array([[1, 2, 3, 2],
-                                 [2, 4, 2, 3],
-                                 [3, 1, 2, 4]])
-        self.scores = np.array([[15, 20, 16, 18, 17],
-                                [21, 32, 19, 26, 27],
-                                [14, 30, 15, 21, 23]])
+        self.weights = np.array([[1, 2, 3],
+                                 [2, 4, 1],
+                                 [3, 2, 2],
+                                 [2, 3, 4]])
+        self.bias = np.array([2, 1, 4])
+        self.scores = np.array([[15, 21, 14],
+                                [20, 32, 30],
+                                [16, 19, 15],
+                                [18, 26, 21],
+                                [17, 27, 23]]) + self.bias
         self.labels = np.array([2, 1, 0, 0, 2])
         self.layer = LayerFullyConnected(
             self.points.shape[1], self.scores.shape[1])
         self.layer.weights = self.weights
+        self.layer.bias = self.bias
         self.classifier = LinearSVM(self.scores.shape)
 
     def test_naive_directed(self):

--- a/layers/test/test_layer_fully_connected.py
+++ b/layers/test/test_layer_fully_connected.py
@@ -66,37 +66,37 @@ class TestLayerFullyConnectedDirected0(unittest.TestCase):
 
 
 class TestLayerFullyConnectedGradientBase(unittest.TestCase):
-    def gradient_batch_points(self, layer, weights, bias, points):
-        return layer.forward_vectorized(points)
+    def gradient_batch_points(self, points):
+        return self.layer.forward_vectorized(points)
 
-    def gradient_bias(self, layer, weights, bias, points):
+    def gradient_bias(self, bias):
         cached_bias = layer.bias
-        layer.bias = bias
-        ret = layer.forward_vectorized(points)
-        layer.bias = cached_bias
+        self.layer.bias = self.bias
+        ret = self.layer.forward_vectorized(self.points)
+        self.layer.bias = cached_bias
         return ret
 
-    def gradient_weights(self, layer, weights, bias, points):
-        cached_weights = layer.weights
-        layer.weights = weights
-        ret = layer.forward_vectorized(points)
-        layer.weights = cached_weights
+    def gradient_weights(self, weights):
+        cached_weights = self.layer.weights
+        self.layer.weights = weights
+        ret = self.layer.forward_vectorized(self.points)
+        self.layer.weights = cached_weights
         return ret
 
     def numerical_d_batch_points(self):
         return eval_numerical_gradient_array(
-            lambda batch_points: self.gradient_batch_points(self.layer, self.weights, self.bias, batch_points),
-            self.points, self.gradient)
+            lambda batch_points: self.gradient_batch_points(batch_points),
+            self.points)
 
     def numerical_d_weights(self):
         return eval_numerical_gradient_array(
-            lambda weights: self.gradient_weights(self.layer, weights, self.bias, self.points),
-            self.weights, self.gradient)
+            lambda weights: self.gradient_weights(weights),
+            self.weights)
 
     def numerical_d_bias(self):
         return eval_numerical_gradient_array(
-            lambda bias: self.gradient_batch_points(self.layer, self.weights, bias, self.points),
-            self.bias, self.gradient)
+            lambda bias: self.gradient_batch_points(bias),
+            self.bias)
 
 
 class TestLayerFullyConnectedDirected1(TestLayerFullyConnectedGradientBase):

--- a/layers/test/test_layer_fully_connected.py
+++ b/layers/test/test_layer_fully_connected.py
@@ -8,7 +8,7 @@ from classifiers.linear_svm import LinearSVM
 from utils.allow_failure import allow_failure
 
 
-class TestLayerFullyConnected(unittest.TestCase):
+class TestLayerFullyConnectedTiming(unittest.TestCase):
     def setUp(self):
         self.num_classes = 100
         self.num_points = 1000

--- a/layers/test/test_layer_fully_connected.py
+++ b/layers/test/test_layer_fully_connected.py
@@ -70,8 +70,8 @@ class TestLayerFullyConnectedGradientBase(unittest.TestCase):
         return self.layer.forward_vectorized(points)
 
     def gradient_bias(self, bias):
-        cached_bias = layer.bias
-        self.layer.bias = self.bias
+        cached_bias = self.layer.bias
+        self.layer.bias = bias
         ret = self.layer.forward_vectorized(self.points)
         self.layer.bias = cached_bias
         return ret
@@ -95,7 +95,7 @@ class TestLayerFullyConnectedGradientBase(unittest.TestCase):
 
     def numerical_d_bias(self):
         return eval_numerical_gradient_array(
-            lambda bias: self.gradient_batch_points(bias),
+            lambda bias: self.gradient_bias(bias),
             self.bias, self.gradient)
 
 
@@ -132,9 +132,9 @@ class TestLayerFullyConnectedDirected1(TestLayerFullyConnectedGradientBase):
         # only for side-effects
         _ = self.layer.forward_vectorized(self.points)
 
-        numerical_d_batch_points = self.numerical_d_batch_points()
-        numerical_d_weights = self.numerical_d_weights()
-        numerical_d_bias = self.numerical_d_bias()
+        numerical_d_batch_points = self.numerical_d_batch_points().copy()
+        numerical_d_weights = self.numerical_d_weights().copy()
+        numerical_d_bias = self.numerical_d_bias().copy()
 
         # only for side-effects
         _ = self.layer.backward_vectorized(self.gradient)

--- a/layers/test/test_layer_fully_connected.py
+++ b/layers/test/test_layer_fully_connected.py
@@ -13,12 +13,10 @@ class TestLayerFullyConnected(unittest.TestCase):
         self.num_classes = 100
         self.num_points = 1000
         self.point_size = 20000
-        self.weights = np.random.randn(self.num_classes, self.point_size)
         self.points = np.random.randn(self.num_points, self.point_size)
 
-    @allow_failure
     def test_timing(self):
-        layer = LayerFullyConnected(self.num_points, self.num_classes, self.weights)
+        layer = LayerFullyConnected(self.point_size, self.num_classes)
         time_naive = time_function(layer.forward_naive, self.points)
         time_vectorized = time_function(layer.forward_vectorized, self.points)
         # the vectorized implementation should become increasingly faster as

--- a/layers/test/test_layer_fully_connected.py
+++ b/layers/test/test_layer_fully_connected.py
@@ -49,7 +49,6 @@ class TestLayerFullyConnectedDirected0(unittest.TestCase):
             self.points.shape[1], self.scores.shape[1])
         self.layer.weights = self.weights
         self.layer.bias = self.bias
-        self.classifier = LinearSVM(self.scores.shape)
 
     def test_naive_directed(self):
         scores = self.layer.forward_naive(self.points)

--- a/layers/test/test_layer_fully_connected.py
+++ b/layers/test/test_layer_fully_connected.py
@@ -17,7 +17,7 @@ class TestLayerFullyConnectedTiming(unittest.TestCase):
 
     @allow_failure
     def test_timing(self):
-        layer = LayerFullyConnected(self.point_size, self.num_classes)
+        layer = LayerFullyConnected((self.point_size, self.num_classes))
         time_naive = time_function(layer.forward_naive, self.points)
         time_vectorized = time_function(layer.forward_vectorized, self.points)
         # the vectorized implementation should become increasingly faster as
@@ -47,7 +47,7 @@ class TestLayerFullyConnectedDirected0(unittest.TestCase):
                                 [17, 27, 23]]) + self.bias
         self.labels = np.array([2, 1, 0, 0, 2])
         self.layer = LayerFullyConnected(
-            self.points.shape[1], self.scores.shape[1])
+            (self.points.shape[1], self.scores.shape[1]))
         self.layer.weights = self.weights
         self.layer.bias = self.bias
 
@@ -113,7 +113,7 @@ class TestLayerFullyConnectedDirected1(TestLayerFullyConnectedGradientBase):
         self.weights = np.linspace(-0.2, 0.3, num=weight_size).reshape(np.prod(input_dim), output_dim)
         self.bias = np.linspace(-0.3, 0.1, num=output_dim)
 
-        self.layer = LayerFullyConnected(input_dim, output_dim)
+        self.layer = LayerFullyConnected((input_dim, output_dim))
         self.layer.weights = self.weights
         self.layer.bias = self.bias
         self.scores = np.array([[1.49834967, 1.70660132, 1.91485297],

--- a/layers/test/test_layer_fully_connected.py
+++ b/layers/test/test_layer_fully_connected.py
@@ -24,7 +24,7 @@ class TestLayerFullyConnectedTiming(unittest.TestCase):
         self.assertLess(time_vectorized * 5, time_naive)
 
 
-class TestLayerFullyConnectedDirected(unittest.TestCase):
+class TestLayerFullyConnectedDirected0(unittest.TestCase):
     def setUp(self):
         # This is a test data set with 4 points per input and 3 output
         # classifications. I have independently precalculated and verified the
@@ -64,3 +64,27 @@ class TestLayerFullyConnectedDirected(unittest.TestCase):
         time_naive = time_function(self.layer.forward_naive, self.points)
         time_vectorized = time_function(self.layer.forward_vectorized, self.points)
         self.assertLess(time_vectorized * 2, time_naive)
+
+
+class TestLayerFullyConnectedDirected1(unittest.TestCase):
+    def setUp(self):
+        num_inputs = 2
+        input_dim = 120
+        output_dim = 3
+
+        input_size = num_inputs * np.prod(input_dim)
+        weight_size = output_dim * np.prod(input_dim)
+
+        self.points = np.linspace(-0.1, 0.5, num=input_size).reshape(num_inputs, input_dim)
+        self.weights = np.linspace(-0.2, 0.3, num=weight_size).reshape(np.prod(input_dim), output_dim)
+        self.bias = np.linspace(-0.3, 0.1, num=output_dim)
+
+        self.layer = LayerFullyConnected(input_dim, output_dim)
+        self.layer.weights = self.weights
+        self.layer.bias = self.bias
+        self.scores = np.array([[1.49834967, 1.70660132, 1.91485297],
+                                [3.25553199, 3.5141327,  3.77273342]])
+
+    def test_vectorized(self):
+        scores = self.layer.forward_vectorized(self.points)
+        self.assertTrue(np.allclose(scores, self.scores))

--- a/layers/test/test_layer_fully_connected.py
+++ b/layers/test/test_layer_fully_connected.py
@@ -86,17 +86,17 @@ class TestLayerFullyConnectedGradientBase(unittest.TestCase):
     def numerical_d_batch_points(self):
         return eval_numerical_gradient_array(
             lambda batch_points: self.gradient_batch_points(batch_points),
-            self.points)
+            self.points, self.gradient)
 
     def numerical_d_weights(self):
         return eval_numerical_gradient_array(
             lambda weights: self.gradient_weights(weights),
-            self.weights)
+            self.weights, self.gradient)
 
     def numerical_d_bias(self):
         return eval_numerical_gradient_array(
             lambda bias: self.gradient_batch_points(bias),
-            self.bias)
+            self.bias, self.gradient)
 
 
 class TestLayerFullyConnectedDirected1(TestLayerFullyConnectedGradientBase):
@@ -139,6 +139,6 @@ class TestLayerFullyConnectedDirected1(TestLayerFullyConnectedGradientBase):
         # only for side-effects
         _ = self.layer.backward_vectorized(self.gradient)
 
-        self.assertTrue(np.allclose(numerical_d_weights, self.layer.d_weights))
         self.assertTrue(np.allclose(numerical_d_batch_points, self.layer.d_batch_points))
+        self.assertTrue(np.allclose(numerical_d_weights, self.layer.d_weights))
         self.assertTrue(np.allclose(numerical_d_bias, self.layer.d_bias))

--- a/lib/gradient_check.py
+++ b/lib/gradient_check.py
@@ -32,7 +32,7 @@ def eval_numerical_gradient(f, x, verbose=True, h=0.00001):
   return grad
 
 
-def eval_numerical_gradient_array(f, x, df, h=1e-5):
+def eval_numerical_gradient_array(f, x, h=1e-5):
   """
   Evaluate a numeric gradient for a function that accepts a numpy
   array and returns a numpy array.
@@ -48,8 +48,7 @@ def eval_numerical_gradient_array(f, x, df, h=1e-5):
     x[ix] = oldval - h
     neg = f(x).copy()
     x[ix] = oldval
-
-    grad[ix] = np.sum((pos - neg) * df) / (2 * h)
+    grad[ix] = np.sum((pos - neg)) / (2 * h)
     it.iternext()
   return grad
 

--- a/lib/gradient_check.py
+++ b/lib/gradient_check.py
@@ -32,7 +32,7 @@ def eval_numerical_gradient(f, x, verbose=True, h=0.00001):
   return grad
 
 
-def eval_numerical_gradient_array(f, x, h=1e-5):
+def eval_numerical_gradient_array(f, x, df, h=1e-5):
   """
   Evaluate a numeric gradient for a function that accepts a numpy
   array and returns a numpy array.
@@ -48,7 +48,7 @@ def eval_numerical_gradient_array(f, x, h=1e-5):
     x[ix] = oldval - h
     neg = f(x).copy()
     x[ix] = oldval
-    grad[ix] = np.sum((pos - neg)) / (2 * h)
+    grad[ix] = np.sum((pos - neg) * df) / (2 * h)
     it.iternext()
   return grad
 

--- a/lib/gradient_check.py
+++ b/lib/gradient_check.py
@@ -1,7 +1,7 @@
 import numpy as np
 from random import randrange
 
-def eval_numerical_gradient(f, x, verbose=True, h=0.00001):
+def eval_numerical_gradient(f, x, verbose=False, h=0.00001):
   """
   a naive implementation of numerical gradient of f at x
   - f should be a function that takes a single argument


### PR DESCRIPTION
This PR consists of the complete implementation of `LayerFullyConected` with vectorized gradient calculations for the inputs, weights, and bias. Previously I implemented a very basic version of `LayerFullyConnected` without gradient calculations for testing, but I realized I needed to make an API change: I transposed the weights `NDArray` so that it's oriented similarly to how the input data is oriented: the original weights were oriented by `(num_outputs, num_inputs)`, where `num_inputs` is the size of the input number of pixels, and `num_outputs` is the number of classifications. I originally used `(num_outputs, num_inputs)` because the vectorized math works out a bit cleaner, but this is inconsistent with the input structures, most of the examples, and seems to confuse more than simplify.

I transposed the `LayerFullyConnected` weights so that it takes the shape `(num_inputs, num_outputs)`, so that it is easy to reason about inputs and outputs dimensions. However, this changes the orientation of the scores that the classifiers receive: they used to receive scores in the shape `(classification_scores, batch_size)`, where `classification_scores` is the `num_outputs` from `LayerFullyConnected`, and `batch_size` is the number of images in a batch. I updated the tests and classifiers to use the new orientation `(batch_size, classification_scores)`, which is consistent with the shape of the imported data set. 

I fully realize that I could've saved myself the trouble by just transposing the scores matrix in the classifiers and the `forward_vectorized` code in `LayerFullyConnected`, thus keeping the classifier and layer code exactly the same. However, I feel that this adds cruft if I am ever to come back to this design and look at it again.

I also added the gradient calculation in the naive implementation of the SVM classifier so the performance test should be a bit more accurate now and changed the `LayerFullyConnected` constructor to take a tuple of the desired transformation instead of two integers.

This PR also resolves #2.