### PR TITLE
Fix/Clean up Classifiers, Fix RegularizerL2, Add 2-Layer Net Connectivity Tests

### DIFF
--- a/classifiers/softmax.py
+++ b/classifiers/softmax.py
@@ -5,7 +5,22 @@ class ClassifierSoftmax():
     def __init__(self, scores_shape):
         self.gradient = np.zeros(scores_shape)
 
-    def forward_naive(self, scores, labels):
+    def set_batch_labels(self, batch_labels):
+        """
+        Set the classification labels for this batch. This is necessary to obtain a proper score.
+
+        Inputs:
+        - batch_labels: The labels corresponding to the current batch.
+
+        Outputs:
+        - none
+
+        Side-Effects:
+        - Stores the input batch_labels locally
+        """
+        self.batch_labels = batch_labels
+
+    def forward_naive(self, scores):
         """
         Softmax loss function, naive implementation (with loops)
 
@@ -17,9 +32,12 @@ class ClassifierSoftmax():
         - labels: A numpy array of shape (N,) containing training labels; labels[i] = c
             means that scores[i] has label c, where 0 <= c < number of labels in scores.
 
-        Returns a tuple of:
+        Outputs:
         - loss as single float
-        - gradient with respect to the scores, same shape as the scores (N, D)
+
+        Side-Effects:
+        - Computes and stores the partial gradient of the output with respect
+          to the input scores
         """
         # Initialize the loss and gradient to zero.
         loss = 0.0
@@ -59,7 +77,7 @@ class ClassifierSoftmax():
         # The naive calculation is below. We store the gradient in self.
         for i in range(num_points):
             for j in range(num_classes):
-                if j == labels[i]:
+                if j == self.batch_labels[i]:
                     # this is really bad because subtraction allows for
                     # numerical instability and dropoff, but it's good enough
                     # for a naive approach
@@ -74,12 +92,12 @@ class ClassifierSoftmax():
                 local_scores[i, j] /= scores_sum[i]
 
         # Finally, we obtain our final loss.
-        correct_classification_indices = (np.arange(num_points), labels)
+        correct_classification_indices = (np.arange(num_points), self.batch_labels)
         loss = np.sum(-1 * np.log(local_scores[correct_classification_indices])) / num_points
 
-        return loss, self.gradient
+        return loss
 
-    def forward(self, scores, labels):
+    def forward(self, scores):
         """
         Softmax loss function, vectorized version.
 
@@ -91,9 +109,12 @@ class ClassifierSoftmax():
         - labels: A numpy array of shape (N,) containing training labels; labels[i] = c
             means that scores[i] has label c, where 0 <= c < number of labels in scores.
 
-        Returns a tuple of:
+        Outputs:
         - loss as single float
-        - gradient with respect to the scores, same shape as the scores (N, D)
+
+        Side-Effects:
+        - Computes and stores the partial gradient of the output with respect
+          to the input scores
         """
         # Initialize the loss to zero.
         loss = 0.0
@@ -121,7 +142,7 @@ class ClassifierSoftmax():
 
         # Third normalize the scores. Both the gradient general case ($j \ne
         # y_i$) and the loss depends on the normalized scores.
-        correct_classification_indices = (np.arange(num_points), labels)
+        correct_classification_indices = (np.arange(num_points), self.batch_labels)
         normalized_scores = (local_scores.T / scores_sum).T
         loss = np.sum(-1 * np.log(normalized_scores[correct_classification_indices])) / num_points
 
@@ -154,4 +175,16 @@ class ClassifierSoftmax():
             -1 * np.sum(noncorrect_classification_index_mask * local_scores) / scores_sum
 
         # All done!
-        return loss, self.gradient
+        return loss
+
+    def backward(self, gradient=1):
+        """
+        Computes the backward pass of the Softmax classifier with the partial
+        gradient from the subsequent layer and returning the partial gradient
+        with respect to the previous layer's inputs.
+
+        Inputs:
+        - gradient: ignored, but exists for API consistency
+        """
+
+        return self.gradient

--- a/classifiers/softmax.py
+++ b/classifiers/softmax.py
@@ -85,6 +85,8 @@ class ClassifierSoftmax():
                 else:
                     self.gradient[i, j] = local_scores[i, j] / scores_sum[i]
 
+        self.gradient /= scores.shape[0]
+
         # Third we normalize each parameter with respect to the other
         # parameters.
         for i in range(num_points):
@@ -172,9 +174,9 @@ class ClassifierSoftmax():
         noncorrect_classification_index_mask = np.ones(local_scores.shape)
         noncorrect_classification_index_mask[correct_classification_indices] = 0
         self.gradient[correct_classification_indices] = \
-            -1 * np.sum(noncorrect_classification_index_mask * local_scores) / scores_sum
+            -np.sum(noncorrect_classification_index_mask * local_scores, axis=1) / scores_sum
+        self.gradient /= scores.shape[0]
 
-        # All done!
         return loss
 
     def backward(self, gradient=1):

--- a/classifiers/test/test_softmax.py
+++ b/classifiers/test/test_softmax.py
@@ -14,7 +14,23 @@ cifar10_dir = 'datasets/cifar-10-batches-py'
 # TODO: clean this up! There's so much duplicated code below...
 
 
-class TestClassifierSoftmax(unittest.TestCase):
+class ClassifierSoftmaxGradientTest():
+    def testGradientNaive(self):
+        self.classifier.forward_naive(self.scores)
+        analyticGradient = self.classifier.gradient.copy()
+        numericalGradient = eval_numerical_gradient(
+            lambda x: self.classifier.forward(x), self.scores)
+        self.assertTrue(np.allclose(numericalGradient, analyticGradient))
+
+    def testGradientVectorized(self):
+        self.classifier.forward(self.scores)
+        analyticGradient = self.classifier.gradient.copy()
+        numericalGradient = eval_numerical_gradient(
+            lambda x: self.classifier.forward(x), self.scores)
+        self.assertTrue(np.allclose(numericalGradient, analyticGradient))
+
+
+class TestClassifierSoftmax(unittest.TestCase, ClassifierSoftmaxGradientTest):
     def setUp(self):
         self.num_train = 500
         self.num_test = 50
@@ -72,7 +88,7 @@ class TestClassifierSoftmax(unittest.TestCase):
         self.assertGreater(loss, 2)
 
 
-class TestClassifierSoftmaxDirected0(unittest.TestCase):
+class TestClassifierSoftmaxDirected0(unittest.TestCase, ClassifierSoftmaxGradientTest):
     def setUp(self):
         self.scores = np.array([[3.2, 5.1, -1.7]])
         self.train_labels = np.array([0])
@@ -88,7 +104,7 @@ class TestClassifierSoftmaxDirected0(unittest.TestCase):
         self.assertAlmostEqual(loss, 2.04035515)
 
 
-class TestClassifierSoftmaxDirected1(unittest.TestCase):
+class TestClassifierSoftmaxDirected1(unittest.TestCase, ClassifierSoftmaxGradientTest):
     def setUp(self):
         self.scores = np.array([[-2.85000, 0.86000, 0.28000]])
         self.train_labels = np.array([2])
@@ -104,7 +120,7 @@ class TestClassifierSoftmaxDirected1(unittest.TestCase):
         self.assertAlmostEqual(loss, 1.04019057)
 
 
-class TestClassifierSoftmaxDirected2(unittest.TestCase):
+class TestClassifierSoftmaxDirected2(unittest.TestCase, ClassifierSoftmaxGradientTest):
     def setUp(self):
         self.scores = np.array([[-2.85, 0.86, 0.28],
                                 [3.2, 5.1, -1.7]])
@@ -121,23 +137,9 @@ class TestClassifierSoftmaxDirected2(unittest.TestCase):
         self.assertAlmostEqual(loss, (1.04019057 + 2.04035515) / 2)
 
 
-class TestClassifierSoftmaxGradient(unittest.TestCase):
+class TestClassifierSoftmaxDirected3(unittest.TestCase, ClassifierSoftmaxGradientTest):
     def setUp(self):
         self.scores = np.array([[15, 21, 14], [5, 2, 4]], dtype=float)
         self.labels = np.array([2, 1])
         self.classifier = ClassifierSoftmax(self.scores.shape)
         self.classifier.set_batch_labels(self.labels)
-
-    def testGradientNaive(self):
-        self.classifier.forward_naive(self.scores)
-        analyticGradient = self.classifier.gradient.copy()
-        numericalGradient = eval_numerical_gradient(
-            lambda x: self.classifier.forward(x), self.scores)
-        self.assertTrue(np.allclose(numericalGradient, analyticGradient))
-
-    def testGradientVectorized(self):
-        self.classifier.forward(self.scores)
-        analyticGradient = self.classifier.gradient.copy()
-        numericalGradient = eval_numerical_gradient(
-            lambda x: self.classifier.forward(x), self.scores)
-        self.assertTrue(np.allclose(numericalGradient, analyticGradient))

--- a/classifiers/test/test_softmax.py
+++ b/classifiers/test/test_softmax.py
@@ -11,10 +11,8 @@ from lib.gradient_check import eval_numerical_gradient
 
 cifar10_dir = 'datasets/cifar-10-batches-py'
 
-# TODO: clean this up! There's so much duplicated code below...
 
-
-class ClassifierSoftmaxGradientTest():
+class ClassifierSoftmaxGradientTest:
     def testGradientNaive(self):
         self.classifier.forward_naive(self.scores)
         analyticGradient = self.classifier.gradient.copy()

--- a/classifiers/test/test_softmax.py
+++ b/classifiers/test/test_softmax.py
@@ -51,20 +51,19 @@ class TestClassifierSoftmax(unittest.TestCase):
         self.layer.weights = np.zeros((self.train_points.shape[1], self.num_classifications))
         self.classifier = ClassifierSoftmax(
             (self.train_points.shape[0], self.num_classifications))
+        self.classifier.set_batch_labels(self.train_labels)
 
         self.scores = self.layer.forward(self.train_points)
 
     def testSoftmaxLossNaive(self):
-        loss, grad = self.classifier.forward_naive(
-            self.scores, self.train_labels)
+        loss = self.classifier.forward_naive(self.scores)
         # Kaparthy says we should expect a probablity around $-\log(0.1) =
         # 2.302$. Check for that here
         self.assertLess(loss, 2.5)
         self.assertGreater(loss, 2)
 
     def testSoftmaxLossVectorized(self):
-        loss, grad = self.classifier.forward(
-            self.scores, self.train_labels)
+        loss = self.classifier.forward(self.scores)
         # Kaparthy says we should expect a probablity around $-\log(0.1) =
         # 2.302$. Check for that here.
         self.assertLess(loss, 2.5)
@@ -76,15 +75,14 @@ class TestClassifierSoftmaxDirected0(unittest.TestCase):
         self.scores = np.array([[3.2, 5.1, -1.7]])
         self.train_labels = np.array([0])
         self.classifier = ClassifierSoftmax(self.scores.shape)
+        self.classifier.set_batch_labels(self.train_labels)
 
     def testSoftmaxLossNaive(self):
-        loss, grad = self.classifier.forward_naive(
-            self.scores, self.train_labels)
+        loss = self.classifier.forward_naive(self.scores)
         self.assertAlmostEqual(loss, 2.04035515)
 
     def testSoftmaxLossVectorized(self):
-        loss, grad = self.classifier.forward(
-            self.scores, self.train_labels)
+        loss = self.classifier.forward(self.scores)
         self.assertAlmostEqual(loss, 2.04035515)
 
 
@@ -93,15 +91,14 @@ class TestClassifierSoftmaxDirected1(unittest.TestCase):
         self.scores = np.array([[-2.85000, 0.86000, 0.28000]])
         self.train_labels = np.array([2])
         self.classifier = ClassifierSoftmax(self.scores.shape)
+        self.classifier.set_batch_labels(self.train_labels)
 
     def testSoftmaxLossNaive(self):
-        loss, grad = self.classifier.forward_naive(
-            self.scores, self.train_labels)
+        loss = self.classifier.forward_naive(self.scores)
         self.assertAlmostEqual(loss, 1.04019057)
 
     def testSoftmaxLossVectorized(self):
-        loss, grad = self.classifier.forward(
-            self.scores, self.train_labels)
+        loss = self.classifier.forward(self.scores)
         self.assertAlmostEqual(loss, 1.04019057)
 
 
@@ -111,15 +108,14 @@ class TestClassifierSoftmaxDirected2(unittest.TestCase):
                                 [3.2, 5.1, -1.7]])
         self.train_labels = np.array([2, 0])
         self.classifier = ClassifierSoftmax(self.scores.shape)
+        self.classifier.set_batch_labels(self.train_labels)
 
     def testSoftmaxLossNaive(self):
-        loss, grad = self.classifier.forward_naive(
-            self.scores, self.train_labels)
+        loss = self.classifier.forward_naive(self.scores)
         self.assertAlmostEqual(loss, (1.04019057 + 2.04035515) / 2)
 
     def testSoftmaxLossVectorized(self):
-        loss, grad = self.classifier.forward(
-            self.scores, self.train_labels)
+        loss = self.classifier.forward(self.scores)
         self.assertAlmostEqual(loss, (1.04019057 + 2.04035515) / 2)
 
 
@@ -129,16 +125,15 @@ class TestClassifierSoftmaxGradient(unittest.TestCase):
         self.scores = np.array([[15, 21, 14]], dtype=float)
         self.labels = np.array([2])
         self.classifier = ClassifierSoftmax(self.scores.shape)
+        self.classifier.set_batch_labels(self.labels)
 
     def testGradientNaive(self):
-        (loss, gradient) = self.classifier.forward_naive(
-            self.scores, self.labels)
-        self.gradientCheck(loss, gradient)
+        loss = self.classifier.forward_naive(self.scores)
+        self.gradientCheck(loss, self.classifier.gradient)
 
     def testGradientVectorized(self):
-        (loss, gradient) = self.classifier.forward(
-            self.scores, self.labels)
-        self.gradientCheck(loss, gradient)
+        loss = self.classifier.forward(self.scores)
+        self.gradientCheck(loss, self.classifier.gradient)
 
     def gradientCheck(self, lossOriginal, analyticGradient):
         # preserve the gradient
@@ -149,8 +144,7 @@ class TestClassifierSoftmaxGradient(unittest.TestCase):
         for row in range(self.scores.shape[0]):
             for col in range(self.scores.shape[1]):
                 self.scores[row, col] += h
-                (loss, _) = self.classifier.forward_naive(
-                    self.scores, self.labels)
+                loss = self.classifier.forward_naive(self.scores)
                 grad = (loss - lossOriginal) / h
                 numericalGradient[row, col] = grad
                 self.scores[row, col] -= h

--- a/classifiers/test/test_svm.py
+++ b/classifiers/test/test_svm.py
@@ -53,29 +53,24 @@ class TestLinearSVM(unittest.TestCase):
         self.layer.weights = np.zeros((self.train_points.shape[1], self.num_classifications))
         self.classifier = ClassifierSVM(
             (self.train_points.shape[0], self.num_classifications))
-
+        self.classifier.set_batch_labels(self.train_labels)
         self.scores = self.layer.forward(self.train_points)
 
     def testSVMLossNaive(self):
-        loss, grad = self.classifier.forward_naive(
-            self.scores, self.train_labels)
+        loss = self.classifier.forward_naive(self.scores)
         self.assertLess(loss, 10)
         self.assertGreater(loss, 8)
+        self.classifier.set_batch_labels(self.train_labels)
 
     def testSVMLossVectorized(self):
-        loss, grad = self.classifier.forward(
-            self.scores, self.train_labels)
+        loss = self.classifier.forward(self.scores)
         self.assertLess(loss, 10)
         self.assertGreater(loss, 8)
 
     @allow_failure
     def testTiming(self):
-        naive_time = time_function(
-            self.classifier.forward_naive,
-            self.scores, self.train_labels)
-        vectorized_time = time_function(
-            self.classifier.forward,
-            self.scores, self.train_labels)
+        naive_time = time_function(self.classifier.forward_naive, self.scores)
+        vectorized_time = time_function(self.classifier.forward, self.scores)
         self.assertLess(vectorized_time * 10, naive_time)
 
 
@@ -96,10 +91,10 @@ class TestLinearSVMDirected0(unittest.TestCase):
                                 [17, 27, 23]])
         self.labels = np.array([2, 1, 0, 0, 2])
         self.classifier = ClassifierSVM(self.scores.shape)
+        self.classifier.set_batch_labels(self.labels)
 
     def testSVMLossVectorized(self):
-        (loss, gradient) = self.classifier.forward(
-            self.scores, self.labels)
+        loss = self.classifier.forward(self.scores)
         self.assertAlmostEqual(loss, 6.4)
 
 
@@ -110,10 +105,10 @@ class TestLinearSVMDirected1(unittest.TestCase):
                                 [2.2, 2.5, -3.1]])
         self.labels = np.array([0, 1, 2])
         self.classifier = ClassifierSVM(self.scores.shape)
+        self.classifier.set_batch_labels(self.labels)
 
     def testSVMLossVectorized(self):
-        (loss, gradient) = self.classifier.forward(
-            self.scores, self.labels)
+        loss = self.classifier.forward(self.scores)
         self.assertAlmostEqual(loss, 5.2666666666666657)
 
 
@@ -124,21 +119,18 @@ class TestLinearSVMGradient(unittest.TestCase):
         self.gradient = np.array([[1, 1, -2]], dtype=float)
         self.labels = np.array([2])
         self.classifier = ClassifierSVM(self.scores.shape)
+        self.classifier.set_batch_labels(self.labels)
 
     def testGradientVectorized(self):
-        (lossOriginal, analyticGradient) = self.classifier.forward(
-            self.scores, self.labels)
-        analyticGradient = analyticGradient.copy()
+        self.classifier.forward(self.scores)
+        analyticGradient = self.classifier.gradient.copy()
         numericalGradient = eval_numerical_gradient(
-            lambda scores: self.classifier.forward(scores, self.labels)[0],
-            self.scores)
+            lambda scores: self.classifier.forward(scores), self.scores)
         self.assertTrue(np.all(np.isclose(numericalGradient, analyticGradient)))
 
     def testGradientNaive(self):
-        (lossOriginal, analyticGradient) = self.classifier.forward_naive(
-            self.scores, self.labels)
-        analyticGradient = analyticGradient.copy()
+        self.classifier.forward_naive(self.scores)
+        analyticGradient = self.classifier.gradient.copy()
         numericalGradient = eval_numerical_gradient(
-            lambda scores: self.classifier.forward_naive(scores, self.labels)[0],
-            self.scores)
+            lambda scores: self.classifier.forward_naive(scores), self.scores)
         self.assertTrue(np.all(np.isclose(numericalGradient, analyticGradient)))

--- a/layers/test/test_two_layer_net.py
+++ b/layers/test/test_two_layer_net.py
@@ -31,12 +31,11 @@ class TestTwoLayerNet(unittest.TestCase):
         self.forward = compose(self.layer0.forward, self.layer0_activations.forward,
                                self.layer1.forward, self.layer1_activations.forward,
                                self.classifier.forward)
-
         self.backward = compose(self.classifier.backward,
                                 self.layer1_activations.backward, self.layer1.backward,
                                 self.layer0_activations.backward, self.layer0.backward)
 
-        self.classifier.labels = self.forward_classifications
+        self.classifier.set_batch_labels(self.forward_classifications)
 
     def test_initialization(self):
         standard_deviation = 1e-2
@@ -61,9 +60,6 @@ class TestTwoLayerNet(unittest.TestCase):
             -5.5, 4.5, num=self.num_points * self.point_size) \
             .reshape(self.point_size, self.num_points) \
             .T
-
-        forward = compose(self.layer0.forward, self.layer0_activations.forward,
-                          self.layer1.forward, self.layer1_activations.forward)
 
         correct_scores = np.asarray(
             [[11.53165108, 12.2917344, 13.05181771, 13.81190102,

--- a/layers/test/test_two_layer_net.py
+++ b/layers/test/test_two_layer_net.py
@@ -12,7 +12,10 @@ from utils.compose import compose
 
 class TestTwoLayerNetFixture(unittest.TestCase):
     def initConstants(self):
-        pass
+        self.num_points = 3
+        self.point_size = 5
+        self.num_classifications = 7
+        self.hidden_layer_size = 50
 
     def initNetwork(self):
         self.forward_input = np.random.randn(self.num_points, self.point_size)
@@ -60,13 +63,6 @@ class TwoLayerNetGradientTest:
 
 
 class TestTwoLayerNetDirected0(TestTwoLayerNetFixture, TwoLayerNetGradientTest):
-    def initConstants(self):
-        self.num_points = 3
-        self.point_size = 5
-        self.num_classifications = 7
-        # self.hidden_layer_size = 50
-        self.hidden_layer_size = 5
-
     def initNetwork(self):
         super().initNetwork()
 
@@ -86,7 +82,7 @@ class TestTwoLayerNetDirected0(TestTwoLayerNetFixture, TwoLayerNetGradientTest):
 
         self.classifier.set_batch_labels(np.array([0, 5, 1]))
 
-    def xtest_forward_fc_only(self):
+    def test_forward_fc_only(self):
         self.forward = compose(self.layer0.forward, self.layer0_activations.forward,
                                self.layer1.forward, self.layer1_activations.forward)
 
@@ -101,7 +97,7 @@ class TestTwoLayerNetDirected0(TestTwoLayerNetFixture, TwoLayerNetGradientTest):
         scores = self.forward(self.forward_input)
         self.assertTrue(np.allclose(scores, correct_scores))
 
-    def xtest_forward(self):
+    def test_forward(self):
         self.classifier.set_batch_labels(np.array([0, 5, 1]))
         self.assertAlmostEqual(self.forward(self.forward_input), 3.4702243556)
 

--- a/layers/test/test_two_layer_net.py
+++ b/layers/test/test_two_layer_net.py
@@ -1,0 +1,76 @@
+import unittest
+import numpy as np
+
+from classifiers.softmax import ClassifierSoftmax
+from layers.relu import LayerReLU
+from layers.fully_connected import LayerFullyConnected
+
+from lib.gradient_check import eval_numerical_gradient_array
+from utils.compose import compose
+
+
+class TestTwoLayerNet(unittest.TestCase):
+    def setUp(self):
+        self.num_points = 3
+        self.point_size = 5
+        self.num_classifications = 7
+        self.hidden_layer_size = 50
+
+        self.forward_input = np.random.randn(self.num_points, self.point_size)
+        self.forward_classifications = np.random.randint(self.num_classifications,
+                                                         size=self.num_points)
+        self.backward_input = np.random.randn(self.num_points, self.num_classifications)
+
+        # first layer, compute 10 classifications per point
+        self.layer0 = LayerFullyConnected((self.point_size, self.hidden_layer_size))
+        self.layer0_activations = LayerReLU()
+        self.layer1 = LayerFullyConnected((self.hidden_layer_size, self.num_classifications))
+        self.layer1_activations = LayerReLU()
+        self.classifier = ClassifierSoftmax((self.num_points, self.num_classifications))
+
+        self.forward = compose(self.layer0.forward, self.layer0_activations.forward,
+                               self.layer1.forward, self.layer1_activations.forward,
+                               self.classifier.forward)
+
+        self.backward = compose(self.classifier.backward,
+                                self.layer1_activations.backward, self.layer1.backward,
+                                self.layer0_activations.backward, self.layer0.backward)
+
+        self.classifier.labels = self.forward_classifications
+
+    def test_initialization(self):
+        standard_deviation = 1e-2
+
+        standard_deviation_layer0_weights = abs(self.layer0.weights.std() - standard_deviation)
+        standard_deviation_layer1_weights = abs(self.layer1.weights.std() - standard_deviation)
+
+        self.assertLess(standard_deviation_layer0_weights, standard_deviation / 10)
+        self.assertLess(standard_deviation_layer1_weights, standard_deviation / 10)
+
+    def test_forward(self):
+        self.layer0.weights = np.linspace(
+            -0.7, 0.3, num=self.point_size * self.hidden_layer_size) \
+            .reshape(self.point_size, self.hidden_layer_size)
+        self.layer0.bias = np.linspace(-0.1, 0.9, num=self.hidden_layer_size)
+        self.layer1.weights = np.linspace(
+            -0.3, 0.4, num=self.hidden_layer_size * self.num_classifications) \
+            .reshape(self.hidden_layer_size, self.num_classifications)
+        self.layer1.bias = np.linspace(-0.9, 0.1, num=self.num_classifications)
+
+        self.forward_input = np.linspace(
+            -5.5, 4.5, num=self.num_points * self.point_size) \
+            .reshape(self.point_size, self.num_points) \
+            .T
+
+        forward = compose(self.layer0.forward, self.layer0_activations.forward,
+                          self.layer1.forward, self.layer1_activations.forward)
+
+        correct_scores = np.asarray(
+            [[11.53165108, 12.2917344, 13.05181771, 13.81190102,
+              14.57198434, 15.33206765, 16.09215096],
+             [12.05769098, 12.74614105, 13.43459113, 14.1230412,
+              14.81149128, 15.49994135, 16.18839143],
+             [12.58373087, 13.20054771, 13.81736455, 14.43418138,
+              15.05099822, 15.66781506, 16.2846319]])
+        scores = forward(self.forward_input)
+        self.assertTrue(np.allclose(scores, correct_scores))

--- a/layers/test/test_two_layer_net.py
+++ b/layers/test/test_two_layer_net.py
@@ -4,6 +4,7 @@ import numpy as np
 from classifiers.softmax import ClassifierSoftmax
 from layers.relu import LayerReLU
 from layers.fully_connected import LayerFullyConnected
+from regularizers.l2 import RegularizerL2
 
 from lib.gradient_check import eval_numerical_gradient_array
 from utils.compose import compose
@@ -27,6 +28,10 @@ class TestTwoLayerNet(unittest.TestCase):
         self.layer1 = LayerFullyConnected((self.hidden_layer_size, self.num_classifications))
         self.layer1_activations = LayerReLU()
         self.classifier = ClassifierSoftmax((self.num_points, self.num_classifications))
+
+        self.regularizer = RegularizerL2()
+        self.regularizer.addLayer(self.layer0)
+        self.regularizer.addLayer(self.layer1)
 
         self.forward = compose(self.layer0.forward, self.layer0_activations.forward,
                                self.layer1.forward, self.layer1_activations.forward,
@@ -77,3 +82,7 @@ class TestTwoLayerNet(unittest.TestCase):
 
         self.classifier.set_batch_labels(np.array([0, 5, 1]))
         self.assertAlmostEqual(self.forward(self.forward_input), 3.4702243556)
+
+        self.assertAlmostEqual(26.5948426952,
+                               self.forward(self.forward_input)
+                               + self.regularizer.calculate())

--- a/layers/test/test_two_layer_net.py
+++ b/layers/test/test_two_layer_net.py
@@ -6,23 +6,20 @@ from layers.relu import LayerReLU
 from layers.fully_connected import LayerFullyConnected
 from regularizers.l2 import RegularizerL2
 
-from lib.gradient_check import eval_numerical_gradient_array
+from lib.gradient_check import eval_numerical_gradient
 from utils.compose import compose
 
 
-class TestTwoLayerNet(unittest.TestCase):
-    def setUp(self):
-        self.num_points = 3
-        self.point_size = 5
-        self.num_classifications = 7
-        self.hidden_layer_size = 50
+class TestTwoLayerNetFixture(unittest.TestCase):
+    def initConstants(self):
+        pass
 
+    def initNetwork(self):
         self.forward_input = np.random.randn(self.num_points, self.point_size)
         self.forward_classifications = np.random.randint(self.num_classifications,
                                                          size=self.num_points)
         self.backward_input = np.random.randn(self.num_points, self.num_classifications)
 
-        # first layer, compute 10 classifications per point
         self.layer0 = LayerFullyConnected((self.point_size, self.hidden_layer_size))
         self.layer0_activations = LayerReLU()
         self.layer1 = LayerFullyConnected((self.hidden_layer_size, self.num_classifications))
@@ -42,16 +39,37 @@ class TestTwoLayerNet(unittest.TestCase):
 
         self.classifier.set_batch_labels(self.forward_classifications)
 
-    def test_initialization(self):
-        standard_deviation = 1e-2
+    def setUp(self):
+        self.initConstants()
+        self.initNetwork()
 
-        standard_deviation_layer0_weights = abs(self.layer0.weights.std() - standard_deviation)
-        standard_deviation_layer1_weights = abs(self.layer1.weights.std() - standard_deviation)
 
-        self.assertLess(standard_deviation_layer0_weights, standard_deviation / 10)
-        self.assertLess(standard_deviation_layer1_weights, standard_deviation / 10)
+class TwoLayerNetGradientTest:
+    def test_gradient(self):
+        for layer in [self.layer0, self.layer1]:
+            numerical_gradient = eval_numerical_gradient(
+                lambda _: self.forward(self.forward_input), layer.weights)
+            self.backward(1)
+            self.assertTrue(np.allclose(numerical_gradient, layer.d_weights))
 
-    def test_forward(self):
+        for layer in [self.layer0, self.layer1]:
+            numerical_gradient = eval_numerical_gradient(
+                lambda _: np.sum(self.forward(self.forward_input)), layer.bias)
+            self.backward(1)
+            self.assertTrue(np.allclose(numerical_gradient, layer.d_bias))
+
+
+class TestTwoLayerNetDirected0(TestTwoLayerNetFixture, TwoLayerNetGradientTest):
+    def initConstants(self):
+        self.num_points = 3
+        self.point_size = 5
+        self.num_classifications = 7
+        # self.hidden_layer_size = 50
+        self.hidden_layer_size = 5
+
+    def initNetwork(self):
+        super().initNetwork()
+
         self.layer0.weights = np.linspace(
             -0.7, 0.3, num=self.point_size * self.hidden_layer_size) \
             .reshape(self.point_size, self.hidden_layer_size)
@@ -66,7 +84,13 @@ class TestTwoLayerNet(unittest.TestCase):
             .reshape(self.point_size, self.num_points) \
             .T
 
-        correct_scores = np.asarray(
+        self.classifier.set_batch_labels(np.array([0, 5, 1]))
+
+    def xtest_forward_fc_only(self):
+        self.forward = compose(self.layer0.forward, self.layer0_activations.forward,
+                               self.layer1.forward, self.layer1_activations.forward)
+
+        correct_scores = np.array(
             [[11.53165108, 12.2917344, 13.05181771, 13.81190102,
               14.57198434, 15.33206765, 16.09215096],
              [12.05769098, 12.74614105, 13.43459113, 14.1230412,
@@ -74,15 +98,30 @@ class TestTwoLayerNet(unittest.TestCase):
              [12.58373087, 13.20054771, 13.81736455, 14.43418138,
               15.05099822, 15.66781506, 16.2846319]])
 
-        forward = compose(self.layer0.forward, self.layer0_activations.forward,
-                          self.layer1.forward, self.layer1_activations.forward)
-
-        scores = forward(self.forward_input)
+        scores = self.forward(self.forward_input)
         self.assertTrue(np.allclose(scores, correct_scores))
 
+    def xtest_forward(self):
         self.classifier.set_batch_labels(np.array([0, 5, 1]))
         self.assertAlmostEqual(self.forward(self.forward_input), 3.4702243556)
 
         self.assertAlmostEqual(26.5948426952,
-                               self.forward(self.forward_input)
-                               + self.regularizer.calculate())
+                               self.forward(self.forward_input) +
+                               self.regularizer.calculate())
+
+
+class TestTwoLayerNetDirected1(TestTwoLayerNetFixture, TwoLayerNetGradientTest):
+    def initConstants(self):
+        self.num_points = 10
+        self.point_size = 50
+        self.num_classifications = 10
+        self.hidden_layer_size = 20
+
+    def test_initialization(self):
+        standard_deviation = 1e-2
+
+        standard_deviation_layer0_weights = abs(self.layer0.weights.std() - standard_deviation)
+        standard_deviation_layer1_weights = abs(self.layer1.weights.std() - standard_deviation)
+
+        self.assertLess(standard_deviation_layer0_weights, standard_deviation / 10)
+        self.assertLess(standard_deviation_layer1_weights, standard_deviation / 10)

--- a/layers/test/test_two_layer_net.py
+++ b/layers/test/test_two_layer_net.py
@@ -68,5 +68,12 @@ class TestTwoLayerNet(unittest.TestCase):
               14.81149128, 15.49994135, 16.18839143],
              [12.58373087, 13.20054771, 13.81736455, 14.43418138,
               15.05099822, 15.66781506, 16.2846319]])
+
+        forward = compose(self.layer0.forward, self.layer0_activations.forward,
+                          self.layer1.forward, self.layer1_activations.forward)
+
         scores = forward(self.forward_input)
         self.assertTrue(np.allclose(scores, correct_scores))
+
+        self.classifier.set_batch_labels(np.array([0, 5, 1]))
+        self.assertAlmostEqual(self.forward(self.forward_input), 3.4702243556)

--- a/lib/gradient_check.py
+++ b/lib/gradient_check.py
@@ -1,7 +1,7 @@
 import numpy as np
 from random import randrange
 
-def eval_numerical_gradient(f, x, verbose=False, h=0.00001):
+def eval_numerical_gradient(f, x, verbose=False, h=1e-6):
   """
   a naive implementation of numerical gradient of f at x
   - f should be a function that takes a single argument

--- a/regularizers/l2.py
+++ b/regularizers/l2.py
@@ -11,5 +11,5 @@ class RegularizerL2():
     def calculate(self):
         regularization = 0.0
         for layer in self.layers:
-            regularization += np.sum(layer.weights * layer.weights)
+            regularization += 0.5 * np.sum(layer.weights * layer.weights)
         return regularization

--- a/regularizers/test/test_regularizer_l2.py
+++ b/regularizers/test/test_regularizer_l2.py
@@ -13,7 +13,7 @@ class TestRegularizerL2Directed(unittest.TestCase):
                                  [2, 4, 2, 3],
                                  [3, 1, 2, 4]])
         self.regularizer.addLayer(self)
-        self.assertAlmostEqual(self.regularizer.calculate(), 81.0)
+        self.assertAlmostEqual(self.regularizer.calculate(), 40.5)
 
     def testRegularizerPrefersL2(self):
         self.regularizer.addLayer(self)


### PR DESCRIPTION
This PR marks the first time we have a somewhat-functioning, ad-hoc, two-layer, network. This process revealed multiple deficiencies in the code:
1. The Softmax classifier was incorrect when given multiple points (images) in a batch.
The Softmax implementation had two bugs and there were holes in the tests which did not reveal the issues. The first bug was that the gradients were not scaled by the number of input points. The second bug was that the gradients at the indices of the correct classifications were not calculated correctly (it needed an `axis=1`).

2. The L2 Regularizer was not properly scaled. The scaling by 1/2 makes the regularizer's gradients 1 so the regularizer has no influence on the farthest gradient.

There are other additions here:
1. I added `set_batch_labels()` on top of the classifiers so that they conform to the `forward()`, `backward()` API.

2. Documentation Cleanups: I indicated Side-Effects when they occurred and updated the Outputs due to (1).

3. Test Cleanups: The Softmax tests now have test fixtures which allow for easier testing and less duplication.

4. Two Layer Network Tests: This was the goal of the PR until it ballooned when I found the bugs, but the PR does include a backprop test of a two-layer network with a forward and backward API.

This resolves #10.