### PR TITLE
Refactor Compose()

### DIFF
--- a/layers/test/test_relu.py
+++ b/layers/test/test_relu.py
@@ -5,7 +5,7 @@ from layers.relu import LayerReLU
 from layers.fully_connected import LayerFullyConnected
 
 from lib.gradient_check import eval_numerical_gradient_array
-from utils.compose import compose
+from utils.functors import chain
 
 
 class TestLayerReLUDirected0(unittest.TestCase):
@@ -44,8 +44,8 @@ class TestLayerFullyConnectedWithLayerReLU(unittest.TestCase):
         self.layer1 = LayerReLU()
 
     def testGradientsFullyConnectedWithReLU(self):
-        run_layers_forward = compose(self.layer0.forward, self.layer1.forward)
-        run_layers_backward = compose(self.layer1.backward, self.layer0.backward)
+        run_layers_forward = chain(self.layer0.forward, self.layer1.forward)
+        run_layers_backward = chain(self.layer1.backward, self.layer0.backward)
 
         # for side-effects
         run_layers_forward(self.forward_input)

--- a/layers/test/test_relu.py
+++ b/layers/test/test_relu.py
@@ -7,13 +7,14 @@ from layers.fully_connected import LayerFullyConnected
 from lib.gradient_check import eval_numerical_gradient_array
 from utils.compose import compose
 
+
 class TestLayerReLUDirected0(unittest.TestCase):
     def setUp(self):
         self.relu = LayerReLU()
         self.input = np.linspace(-0.5, 0.5, num=12).reshape(3, 4)
-        self.activations = np.array([[0,          0,          0,          0         ],
-                                     [0,          0,          0.04545455, 0.13636364],
-                                     [0.22727273, 0.31818182, 0.40909091, 0.5       ]])
+        self.activations = np.array([[0, 0, 0, 0],
+                                     [0, 0, 0.04545455, 0.13636364],
+                                     [0.22727273, 0.31818182, 0.40909091, 0.5]])
         self.gradient_in = np.random.randn(*self.input.shape)
 
     def testReLU(self):
@@ -21,7 +22,7 @@ class TestLayerReLUDirected0(unittest.TestCase):
         self.assertTrue(np.allclose(self.activations, activations))
 
     def testGradient(self):
-        _ = self.relu.forward(self.input)
+        self.relu.forward(self.input)
         analyticGradient = self.relu.backward(self.gradient_in)
         numericalGradient = eval_numerical_gradient_array(
             lambda inputs: self.relu.forward(inputs), self.input, self.gradient_in)
@@ -31,7 +32,6 @@ class TestLayerReLUDirected0(unittest.TestCase):
 
 class TestLayerFullyConnectedWithLayerReLU(unittest.TestCase):
     def setUp(self):
-
         num_images = 50
         image_size = 100
         num_classifications = 10
@@ -48,7 +48,7 @@ class TestLayerFullyConnectedWithLayerReLU(unittest.TestCase):
         run_layers_backward = compose(self.layer1.backward, self.layer0.backward)
 
         # for side-effects
-        _ = run_layers_forward(self.forward_input)
+        run_layers_forward(self.forward_input)
         layer0_backward_analytic = run_layers_backward(self.backward_input)
 
         layer0_backward_numerical = eval_numerical_gradient_array(

--- a/layers/test/test_two_layer_net.py
+++ b/layers/test/test_two_layer_net.py
@@ -7,7 +7,7 @@ from layers.fully_connected import LayerFullyConnected
 from regularizers.l2 import RegularizerL2
 
 from lib.gradient_check import eval_numerical_gradient
-from utils.compose import compose
+from utils.functors import chain
 
 
 class TestTwoLayerNetFixture(unittest.TestCase):
@@ -33,10 +33,10 @@ class TestTwoLayerNetFixture(unittest.TestCase):
         self.regularizer.addLayer(self.layer0)
         self.regularizer.addLayer(self.layer1)
 
-        self.forward = compose(self.layer0.forward, self.layer0_activations.forward,
+        self.forward = chain(self.layer0.forward, self.layer0_activations.forward,
                                self.layer1.forward, self.layer1_activations.forward,
                                self.classifier.forward)
-        self.backward = compose(self.classifier.backward,
+        self.backward = chain(self.classifier.backward,
                                 self.layer1_activations.backward, self.layer1.backward,
                                 self.layer0_activations.backward, self.layer0.backward)
 
@@ -83,7 +83,7 @@ class TestTwoLayerNetDirected0(TestTwoLayerNetFixture, TwoLayerNetGradientTest):
         self.classifier.set_batch_labels(np.array([0, 5, 1]))
 
     def test_forward_fc_only(self):
-        self.forward = compose(self.layer0.forward, self.layer0_activations.forward,
+        self.forward = chain(self.layer0.forward, self.layer0_activations.forward,
                                self.layer1.forward, self.layer1_activations.forward)
 
         correct_scores = np.array(

--- a/utils/compose.py
+++ b/utils/compose.py
@@ -1,7 +1,0 @@
-import functools
-
-
-def compose(*functions):
-    def composed(f, g):
-        return lambda x: f(g(x))
-    return functools.reduce(composed, functions[::-1], lambda x: x)

--- a/utils/compose.py
+++ b/utils/compose.py
@@ -2,6 +2,6 @@ import functools
 
 
 def compose(*functions):
-    def compose2(f, g):
+    def composed(f, g):
         return lambda x: f(g(x))
-    return functools.reduce(compose2, functions[::-1], lambda x: x)
+    return functools.reduce(composed, functions[::-1], lambda x: x)

--- a/utils/functors.py
+++ b/utils/functors.py
@@ -1,0 +1,58 @@
+import functools
+
+
+def compose(*functions):
+    """
+    Creates a function composition (e.g. f(g(h(x))) given (f, g, h)) of the
+    given functions, in which the innermost function is the rightmost list
+    element.
+
+    Inputs:
+    - *functions: The functions to compose.
+
+    Outputs:
+    - reduction(): A function which applies the composition
+
+      Inputs:
+      - The input to the composition, e.g. x
+
+      Outputs:
+      - The result of the composition, e.g. f(g(h(x)))
+
+    Example:
+    - y = compose(f, g, h) returns a function which applies f(g(h(x))). We can
+      call the reduction simply by issuing y(x), given a compatible input x.
+    """
+    def _composed(f, g):
+        return lambda x: f(g(x))
+
+    return functools.reduce(_composed, functions, lambda x: x)
+
+
+def chain(*functions):
+    """
+    Creates a function chain (i.e. h(g(f(x))) given (f, g, h)) of the given
+    functions, in which the each list element is applied, in turn, to the
+    input, chaining the output from the previous function application to the
+    next function application.
+
+    Inputs:
+    - *functions: The functions to chain.
+
+    Outputs:
+    - reduction(): A function which applies the chain
+
+      Inputs:
+      - The input to the chain, e.g. x
+
+      Outputs:
+      - The result of the composition, e.g. h(g(f(x)))
+
+    Example:
+    - y = chain(f, g, h) returns a function which applies h(g(f(x))). We can
+      call the reduction simply by issuing y(x), given a compatible input x.
+    """
+    def _chained(f, g):
+        return lambda x: g(f(x))
+
+    return functools.reduce(_chained, functions, lambda x: x)

--- a/utils/functors.py
+++ b/utils/functors.py
@@ -21,7 +21,7 @@ def compose(*functions):
 
     Example:
     - y = compose(f, g, h) returns a function which applies f(g(h(x))). We can
-      call the reduction simply by issuing y(x), given a compatible input x.
+      call the reduction simply by calling y(x), given a compatible input x.
     """
     def _composed(f, g):
         return lambda x: f(g(x))
@@ -32,9 +32,9 @@ def compose(*functions):
 def chain(*functions):
     """
     Creates a function chain (i.e. h(g(f(x))) given (f, g, h)) of the given
-    functions, in which the each list element is applied, in turn, to the
-    input, chaining the output from the previous function application to the
-    next function application.
+    functions, in which the each element is applied, in turn, to the input,
+    chaining the output from the previous function to the input of the next
+    function.
 
     Inputs:
     - *functions: The functions to chain.
@@ -46,11 +46,11 @@ def chain(*functions):
       - The input to the chain, e.g. x
 
       Outputs:
-      - The result of the composition, e.g. h(g(f(x)))
+      - The result of the chain, e.g. h(g(f(x)))
 
     Example:
     - y = chain(f, g, h) returns a function which applies h(g(f(x))). We can
-      call the reduction simply by issuing y(x), given a compatible input x.
+      call the reduction simply by calling y(x), given a compatible input x.
     """
     def _chained(f, g):
         return lambda x: g(f(x))

--- a/utils/functors.py
+++ b/utils/functors.py
@@ -1,34 +1,6 @@
 import functools
 
 
-def compose(*functions):
-    """
-    Creates a function composition (e.g. f(g(h(x))) given (f, g, h)) of the
-    given functions, in which the innermost function is the rightmost list
-    element.
-
-    Inputs:
-    - *functions: The functions to compose.
-
-    Outputs:
-    - reduction(): A function which applies the composition
-
-      Inputs:
-      - The input to the composition, e.g. x
-
-      Outputs:
-      - The result of the composition, e.g. f(g(h(x)))
-
-    Example:
-    - y = compose(f, g, h) returns a function which applies f(g(h(x))). We can
-      call the reduction simply by calling y(x), given a compatible input x.
-    """
-    def _composed(f, g):
-        return lambda x: f(g(x))
-
-    return functools.reduce(_composed, functions, lambda x: x)
-
-
 def chain(*functions):
     """
     Creates a function chain (i.e. h(g(f(x))) given (f, g, h)) of the given
@@ -56,3 +28,31 @@ def chain(*functions):
         return lambda x: g(f(x))
 
     return functools.reduce(_chained, functions, lambda x: x)
+
+
+def compose(*functions):
+    """
+    Creates a function composition (e.g. f(g(h(x))) given (f, g, h)) of the
+    given functions, in which the innermost function is the rightmost list
+    element.
+
+    Inputs:
+    - *functions: The functions to compose.
+
+    Outputs:
+    - reduction(): A function which applies the composition
+
+      Inputs:
+      - The input to the composition, e.g. x
+
+      Outputs:
+      - The result of the composition, e.g. f(g(h(x)))
+
+    Example:
+    - y = compose(f, g, h) returns a function which applies f(g(h(x))). We can
+      call the reduction simply by calling y(x), given a compatible input x.
+    """
+    def _composed(f, g):
+        return lambda x: f(g(x))
+
+    return functools.reduce(_composed, functions, lambda x: x)

--- a/utils/test/test_functors.py
+++ b/utils/test/test_functors.py
@@ -1,0 +1,31 @@
+import unittest
+
+from utils.functors import chain, compose
+
+
+class TestFunctorsBase(unittest.TestCase):
+    def setUp(self):
+        self.add = lambda i: (lambda x: x + i)
+        self.sub = lambda i: (lambda x: x - i)
+        self.mul = lambda i: (lambda x: x * i)
+        self.div = lambda i: (lambda x: x / i)
+
+
+class TestFunctorsChain(TestFunctorsBase):
+    def test_two(self):
+        self.assertEqual(chain(self.add(2), self.div(3))(10),
+                         (10 + 2) / 3)
+
+    def test_three(self):
+        self.assertEqual(chain(self.add(2), self.div(3), self.mul(2))(10),
+                         (10 + 2) / 3 * 2)
+
+
+class TestFunctorsCompose(TestFunctorsBase):
+    def test_two(self):
+        self.assertEqual(compose(self.add(2), self.div(3))(10),
+                         (10 / 3) + 2)
+
+    def test_three(self):
+        self.assertEqual(compose(self.add(2), self.div(3), self.mul(2))(10),
+                         ((10 * 2) / 3) + 2)


### PR DESCRIPTION
I refactored `compose.compose()` info a `functors` module, and cleaned up the naming. 

`compose()` was used incorrectly, as the intent in the `layers` package was to chain layers, not compose. Thus I created both `compose()` and `chain()`, added tests, and renamed the module to `functors`.

Is the `functors` name accurate for what the module does?